### PR TITLE
:sparkles: Support scope with undefined argument.

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ const Sorter = {
      * @param {Array<string>|undefined} acceptableKeys - Acceptable sort keys. (accept all attrs in this Model if undefined.)
      */
     cls.addScope('sortable', function(params, acceptableKeys) {
-      if (!params.sort || params.sort.length === 0) {
+      if (!params || !params.sort || params.sort.length === 0) {
         return {};
       }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -29,7 +29,21 @@ describe('Sorter', () => {
   });
 
   describe('sortable scope', () => {
-    describe('with undefined', () => {
+    describe('without sort key', () => {
+      it('should not throw error.', () => {
+        co(function * () {
+          const userIds = yield User.scope({method: ['sortable', undefined]})
+            .findAll()
+            .then((users) => {
+              return users.map((user) => user.get('id'));
+            });
+
+          expect(userIds).to.eql(makeIds(1, 100));
+        });
+      });
+    });
+
+    describe('with undefined value', () => {
       it('should not throw error.', () => {
         co(function * () {
           const params = {sort: undefined};


### PR DESCRIPTION
sortable scopeの引数に`undefined`が指定されたケースをsupportするように修正しました